### PR TITLE
Fixed bower.json syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "2.1.3",
-},
+    "jquery": "2.1.3"
+  }
 }


### PR DESCRIPTION
After running `bower install jquery.appear --save`, we get this following error:

```
bower EMALFORMED
Additional error details:
Unexpected token }
```
